### PR TITLE
new pandas version deprecates append: swtich to concat

### DIFF
--- a/src/marine_eov_broker/MarineRiBroker.py
+++ b/src/marine_eov_broker/MarineRiBroker.py
@@ -520,7 +520,7 @@ class BrokerResponse():
             self.queries = query_line
         else:
             logger.debug(f"Adding dataset {query.dataset.name} to existing dataframe.")
-            self.queries = self.queries.append(query_line)
+            self.queries = pd.concat([self.queries, query_line])
     
     def get_dataset(self, dataset_id):
         '''


### PR DESCRIPTION
Did not need any additions to setup.cfg content.  
Noticed a deprecation in pandas api so updated a bit the code (i think i gained performances by switching from DataFrame.append(df) to pd.concat([df1, df2]) !